### PR TITLE
commented out associations in Interest and UserInterest for taggable gem

### DIFF
--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -1,6 +1,7 @@
 class Interest < ApplicationRecord
-  # ass
-  belongs_to :user, through: :userinterests, dependent: :destroy
+  # Commented out for Taggable Gem. Do not use this Model.
+
+  # belongs_to :user, through: :userinterests, dependent: :destroy
 
   # vals
   validates :name, presence: true

--- a/app/models/userinterest.rb
+++ b/app/models/userinterest.rb
@@ -1,4 +1,6 @@
 class Userinterest < ApplicationRecord
-  belongs_to :user
-  belongs_to :interest
+  # Commented out for Taggable Gem. Do not use this Model.
+
+  # belongs_to :user
+  # belongs_to :interest
 end


### PR DESCRIPTION
• Commented out any existing associations in Interest and UserInterest models to see if this fixes an issue with deploying to Heroku

• We are using Taggable Gem which may not require the need for either of these models