### PR TITLE
chatrooms now link to existing chat if already created

### DIFF
--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -12,7 +12,8 @@ class ChatroomsController < ApplicationController
   end
 
   def create
-    @chatroom = Chatroom.new(chatroom_params)
+    # @chatroom = Chatroom.new(chatroom_params)
+    @chatroom = Chatroom.find_or_create_by(chatroom_params)
     @user_two = User.find(params[:user_two_id])
 
     @chatroom.user = current_user


### PR DESCRIPTION
• This was easier than expected -

Used _find_or_create_by_ method to find an existing chatroom or create a new passing in the chatroom_params

All set!